### PR TITLE
Add static marketing site for personal chef

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chef à domicile — Élise Martin</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600&family=Inter:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="nav">
+        <a class="logo" href="#">Élise Martin</a>
+        <div class="nav-links">
+          <a href="#prestations">Prestations</a>
+          <a href="#menus">Menus</a>
+          <a href="#experience">Expérience</a>
+          <a href="#contact">Contact</a>
+        </div>
+      </nav>
+
+      <div class="hero-content">
+        <div>
+          <p class="eyebrow">Chef à domicile à Nantes & alentours</p>
+          <h1>Des dîners sur-mesure qui célèbrent le terroir.</h1>
+          <p class="lead">
+            Je cuisine chez vous, pour vos invités, avec une approche créative et des produits locaux.
+            Une expérience gastronomique sans stress, du marché à l'assiette.
+          </p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="#contact">Réserver une date</a>
+            <a class="btn btn-secondary" href="#menus">Découvrir les menus</a>
+          </div>
+          <div class="hero-stats">
+            <div>
+              <strong>120+</strong>
+              <span>événements privés</span>
+            </div>
+            <div>
+              <strong>15 ans</strong>
+              <span>d'expérience en cuisine</span>
+            </div>
+            <div>
+              <strong>100 %</strong>
+              <span>produits de saison</span>
+            </div>
+          </div>
+        </div>
+        <div class="hero-card">
+          <p class="badge">Disponible dès novembre</p>
+          <h3>Soirées intimes & grandes tablées</h3>
+          <ul>
+            <li>Menu personnalisé et adapté aux régimes</li>
+            <li>Vaisselle et dressage inclus</li>
+            <li>Service discret et chaleureux</li>
+          </ul>
+          <a class="btn btn-tertiary" href="#contact">Demander un devis</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="prestations" class="section">
+        <div class="section-header">
+          <h2>Prestations sur-mesure</h2>
+          <p>Des formules modulables pour vos dîners, brunchs ou événements d'entreprise.</p>
+        </div>
+        <div class="grid three">
+          <article class="card">
+            <h3>Dîner gastronomique</h3>
+            <p>
+              4 à 7 services inspirés des saisons, avec accords mets & vins conseillés.
+            </p>
+            <span class="tag">À partir de 85 € / pers.</span>
+          </article>
+          <article class="card">
+            <h3>Brunch signature</h3>
+            <p>
+              Viennoiseries maison, œufs créatifs, granola, jus frais et buffets colorés.
+            </p>
+            <span class="tag">À partir de 45 € / pers.</span>
+          </article>
+          <article class="card">
+            <h3>Ateliers cuisine</h3>
+            <p>
+              Cours interactifs pour équipes ou familles, recettes faciles à reproduire.
+            </p>
+            <span class="tag">Sur devis</span>
+          </article>
+        </div>
+      </section>
+
+      <section id="menus" class="section alt">
+        <div class="section-header">
+          <h2>Exemples de menus</h2>
+          <p>Les menus s'adaptent à vos envies, allergies et préférences.</p>
+        </div>
+        <div class="grid two">
+          <div class="menu-card">
+            <h3>Menu « Rivages atlantiques »</h3>
+            <ul>
+              <li>Carpaccio de Saint-Jacques, agrumes & herbes fraîches</li>
+              <li>Bar de ligne, bouillon safrané, légumes croquants</li>
+              <li>Fromages affinés de la région</li>
+              <li>Tarte fine aux poires, crème de lait ribot</li>
+            </ul>
+          </div>
+          <div class="menu-card">
+            <h3>Menu « Jardin d'automne »</h3>
+            <ul>
+              <li>Velouté de potimarron, noisettes torréfiées</li>
+              <li>Risotto aux cèpes, tuile de parmesan</li>
+              <li>Suprême de volaille, jus réduit au thym</li>
+              <li>Poire pochée, caramel au sarrasin</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="experience" class="section">
+        <div class="grid two align-center">
+          <div>
+            <h2>Une expérience pensée pour vos invités</h2>
+            <p>
+              Je prends en charge chaque étape : sourcing des produits, préparation sur place,
+              dressage et service. Vous profitez de vos convives pendant que je cuisine.
+            </p>
+            <div class="checklist">
+              <div>
+                <span>✓</span>
+                <p>Organisation fluide et discrète.</p>
+              </div>
+              <div>
+                <span>✓</span>
+                <p>Recettes créatives inspirées des producteurs locaux.</p>
+              </div>
+              <div>
+                <span>✓</span>
+                <p>Options végétariennes, vegan et sans gluten.</p>
+              </div>
+            </div>
+          </div>
+          <div class="testimonial">
+            <p>
+              « Élise a transformé notre anniversaire en un moment magique. Les plats étaient
+              sublimes, et la cuisine est restée impeccable. »
+            </p>
+            <div>
+              <strong>Camille & Julien</strong>
+              <span>Nantes</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section cta">
+        <div>
+          <h2>Parlons de votre prochain événement</h2>
+          <p>Réponse en moins de 24h. Devis personnalisé et gratuit.</p>
+        </div>
+        <a class="btn btn-primary" href="#contact">Demander une proposition</a>
+      </section>
+
+      <section id="contact" class="section alt">
+        <div class="section-header">
+          <h2>Contact</h2>
+          <p>Décrivez votre événement et je vous réponds rapidement.</p>
+        </div>
+        <div class="grid two">
+          <div class="contact-card">
+            <h3>Informations</h3>
+            <p><strong>Email :</strong> bonjour@elisemartin.com</p>
+            <p><strong>Téléphone :</strong> 06 12 34 56 78</p>
+            <p><strong>Zone :</strong> Nantes, La Baule, Pornic, Cholet</p>
+            <p><strong>Disponibilités :</strong> midi & soir, 7j/7 sur réservation</p>
+          </div>
+          <form class="contact-form">
+            <label>
+              Nom & prénom
+              <input type="text" placeholder="Votre nom" />
+            </label>
+            <label>
+              Email
+              <input type="email" placeholder="nom@email.com" />
+            </label>
+            <label>
+              Date souhaitée
+              <input type="date" />
+            </label>
+            <label>
+              Message
+              <textarea placeholder="Nombre d'invités, budget, envies..."></textarea>
+            </label>
+            <button type="submit" class="btn btn-tertiary">Envoyer la demande</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>© 2024 Élise Martin — Chef à domicile. Tous droits réservés.</p>
+      <div class="footer-links">
+        <a href="#">Mentions légales</a>
+        <a href="#contact">Réserver</a>
+        <a href="#menus">Menus</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,334 @@
+:root {
+  --bg: #f8f4ef;
+  --text: #1d1a17;
+  --muted: #6d645a;
+  --accent: #b46a4f;
+  --accent-dark: #8b4e39;
+  --card: #ffffff;
+  --line: #e5ddd5;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.hero {
+  padding: 48px 8vw 80px;
+  background: linear-gradient(135deg, #fff8f1 0%, #f3e8dc 100%);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.logo {
+  font-family: "Playfair Display", serif;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.nav-links {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 40px;
+  margin-top: 64px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: var(--accent-dark);
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+h1,
+h2,
+h3 {
+  font-family: "Playfair Display", serif;
+}
+
+h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  line-height: 1.2;
+  margin-bottom: 20px;
+}
+
+.lead {
+  font-size: 1.05rem;
+  color: var(--muted);
+  margin-bottom: 28px;
+}
+
+.hero-cta {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn-secondary {
+  background: transparent;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.btn-tertiary {
+  background: var(--text);
+  color: #fff;
+}
+
+.hero-stats {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  color: var(--muted);
+}
+
+.hero-stats strong {
+  font-size: 1.2rem;
+  color: var(--text);
+}
+
+.hero-card {
+  background: var(--card);
+  padding: 28px;
+  border-radius: 24px;
+  box-shadow: 0 18px 40px rgba(120, 88, 69, 0.15);
+  display: grid;
+  gap: 16px;
+}
+
+.hero-card ul {
+  list-style: none;
+  display: grid;
+  gap: 12px;
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-flex;
+  background: #f4e4d8;
+  color: var(--accent-dark);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.section {
+  padding: 72px 8vw;
+}
+
+.section.alt {
+  background: #fffdfb;
+}
+
+.section-header {
+  max-width: 620px;
+  margin-bottom: 36px;
+}
+
+.section-header p {
+  color: var(--muted);
+  margin-top: 12px;
+}
+
+.grid {
+  display: grid;
+  gap: 24px;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.grid.three {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card,
+.menu-card,
+.contact-card,
+.testimonial {
+  background: var(--card);
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid var(--line);
+}
+
+.card h3 {
+  margin-bottom: 12px;
+}
+
+.card p,
+.menu-card li,
+.contact-card p {
+  color: var(--muted);
+}
+
+.tag {
+  display: inline-block;
+  margin-top: 16px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent-dark);
+}
+
+.menu-card ul {
+  list-style: disc;
+  padding-left: 20px;
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.align-center {
+  align-items: center;
+}
+
+.checklist {
+  margin-top: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.checklist div {
+  display: flex;
+  gap: 12px;
+}
+
+.checklist span {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.testimonial {
+  background: #fff4ea;
+  display: grid;
+  gap: 20px;
+  font-style: italic;
+}
+
+.testimonial strong {
+  font-style: normal;
+  display: block;
+}
+
+.cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  background: var(--text);
+  color: #fff;
+  border-radius: 32px;
+  margin: 0 8vw 72px;
+  padding: 48px;
+}
+
+.cta p {
+  opacity: 0.8;
+}
+
+.contact-form {
+  display: grid;
+  gap: 16px;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+input,
+textarea {
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  padding: 12px;
+  font-family: inherit;
+  font-size: 0.95rem;
+}
+
+textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.footer {
+  padding: 32px 8vw 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.footer-links {
+  display: flex;
+  gap: 18px;
+}
+
+@media (max-width: 720px) {
+  .cta {
+    flex-direction: column;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a simple static landing page to showcase a personal chef’s services, menus and contact information.
- Offer a responsive, branded template (hero, services, menus, testimonial, contact) so the chef can share a polished online presence quickly.

### Description

- Add `site/index.html` containing the full static markup for the chef showcase, including hero, prestations, menus, expérience, contact form and footer.
- Add `site/styles.css` with global variables, typography, layout grid, card components, CTA styles and responsive rules for mobile.
- Files are static and standalone so they can be served by any static host or locally with a simple HTTP server.

### Testing

- Started a local server with `python3 -m http.server 8000` and the site served successfully at `http://127.0.0.1:8000/index.html`.
- Captured a full-page screenshot using a Playwright script which saved `artifacts/chef-site.png`, indicating the layout renders as expected.
- No unit tests were run because the change only adds static assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a1ce0678832cbd98d224cbe9657f)